### PR TITLE
Fix Irazasyed\Larasupport\Console\VendorPublishCommand::handle method…

### DIFF
--- a/src/VendorPublishCommand.php
+++ b/src/VendorPublishCommand.php
@@ -41,6 +41,15 @@ class VendorPublishCommand extends Command
         $this->files = $files;
     }
     /**
+     * Compatiblity for Lumen 5.5.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->fire();
+    }
+    /**
      * Execute the console command.
      *
      * @return void


### PR DESCRIPTION
Fix `Irazasyed\Larasupport\Console\VendorPublishCommand::handle` method in `Lumen 5.5` does not exist.