### PR TITLE
Update composer.json for lumen 6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
   },
   "minimum-stability": "stable",
   "require": {
-    "illuminate/console": "^5.0",
-    "illuminate/filesystem": "^5.0",
-    "illuminate/support": "^5.0",
+    "illuminate/console": "^5.1|^6",
+    "illuminate/filesystem": "^5.1|^6",
+    "illuminate/support": "^5.1|^6",
     "league/flysystem": "^1.0"
   }
 }


### PR DESCRIPTION
Util Marge
Clone my repo and paste it outside your project folder

`git clone --single-branch --branch lumen-6-support https://github.com/royrakesh/lumen-vendor-publish.git`

Then add this code into your composer.json
http://prntscr.com/phfb1c
`  "repositories": [
    {
        "type": "path",
        "url": "../lumen-vendor-publish-lumen-6-support",
        "options": {
            "symlink": true
        }
    }
    ]`

http://prntscr.com/phfbzf

` "require": {
        "php": "^7.2",
        "laravel/lumen-framework": "^6.0",
        "laravelista/lumen-vendor-publish":"@dev"
    },`

then run `composer update laravelista/lumen-vendor-publish --prefer-source`

Then configure as per https://github.com/laravelista/lumen-vendor-publish#vendorpublish-for-lumen-framework